### PR TITLE
🔊 Add Speech-to-Text Functionality and Update Setup Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,4 @@ data/datasets/*
 
 # model checkpoints
 models/checkpoints/*
+fish-speech/*

--- a/.gitignore
+++ b/.gitignore
@@ -245,6 +245,7 @@ data/raw/*
 data/processed/*
 data/transcriptions/*
 data/datasets/*
+data/speech-to-text/*
 
 # model checkpoints
 models/checkpoints/*

--- a/README.md
+++ b/README.md
@@ -59,3 +59,20 @@ python "$HOME/workspace/GenLipSyncVideo/scripts/separate.py" \
 
 - `--input` または `--directory` のいずれかを指定する必要があります。両方指定されていない場合、エラーが発生します。
 - 出力ディレクトリが存在しない場合は、自動的に作成されます。
+
+### Speech-to-Text with OpenAI Whisper
+
+1. `speech_to_text.py` は、指定されたWAVファイルをテキストに変換するスクリプトです。以下のコマンドを使用してスクリプトを実行できます。
+
+```bash
+deactivate
+source ../venv/bin/activate
+```
+
+#### 引数の説明
+
+- `--input`: 入力する単一のWAVファイルのパス（例: `"$HOME/workspace/GenLipSyncVideo/data/raw/d_208302/d_208302_track_001.wav"`）
+- `--output`: 出力するテキストファイルのパス（例: `"$HOME/workspace/GenLipSyncVideo/data/raw/text/d_208302_track_001.txt"`）
+- `--dmm-id`: DMM ID（例: `d_208302`）。指定された場合、出力ファイルの名前に追加されます。
+- `--model`: [使用するモデル](https://github.com/openai/whisper?tab=readme-ov-file#available-models-and-languages)（例: `tiny`, `base`, `small`, `medium`, `large`, `turbo`）
+-

--- a/README.md
+++ b/README.md
@@ -19,18 +19,6 @@ source ../venv/bin/activate
 # separate.py の使い方
 ```
 
-#### wav ファイルの分割
-
-```bash
-python "$HOME/workspace/GenLipSyncVideo/scripts/separate.py" \
-  --input "$HOME/workspace/GenLipSyncVideo/data/raw/d_208302/d_208302_track_001.wav" \
-  --output "$HOME/workspace/GenLipSyncVideo/data/raw/separate" \
-  --dmm-id d_208302 \
-  --start 0 \
-  --interval 5 \
-  --duration 15
-```
-
 #### 引数の説明
 
 - `--input`: 入力する単一のWAVファイルのパス（例: `"$HOME/workspace/GenLipSyncVideo/data/raw/d_208302/d_208302_track_001.wav"`）
@@ -40,6 +28,32 @@ python "$HOME/workspace/GenLipSyncVideo/scripts/separate.py" \
 - `--start`: 分割開始時間（秒）（例: `0`）
 - `--interval`: 分割間隔（秒）（例: `5`）
 - `--duration`: 各分割ファイルの長さ（秒）（例: `15`）
+
+#### 個別で DMM の wav ファイルを分割
+
+```bash
+cd "$HOME/workspace/fish-speech"
+python "$HOME/workspace/GenLipSyncVideo/scripts/separate.py" \
+  --input "$HOME/workspace/GenLipSyncVideo/data/raw/d_208302/d_208302_track_001.wav" \
+  --output "$HOME/workspace/GenLipSyncVideo/data/raw/separate" \
+  --dmm-id d_208302 \
+  --start 0 \
+  --interval 5 \
+  --duration 15
+```
+
+#### 一括で DMM の wav ファイルを分割
+
+```bash
+cd "$HOME/workspace/fish-speech"
+python "$HOME/workspace/GenLipSyncVideo/scripts/separate.py" \
+  --directory "$HOME/workspace/GenLipSyncVideo/data/raw/d_208302" \
+  --output "$HOME/workspace/GenLipSyncVideo/data/raw/separate" \
+  --dmm-id d_208302 \
+  --start 0 \
+  --interval 5 \
+  --duration 15
+```
 
 #### 注意事項
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# dummy-speaker
+# GenLipSyncVideo
+
+## Using
+
+### Setup
+
+```bash
+bash ./setup
+```
+
+### Separate
+
+1. wav ファイルを分割する。`bash ./setup` 実行後、fish-speech のディレクトリで実行すること。
+2. `separate.py` は、指定されたWAVファイルを指定の間隔で分割するスクリプトです。以下のコマンドを使用してスクリプトを実行できます。
+
+```bash
+deactivate
+source ../venv/bin/activate
+# separate.py の使い方
+```
+
+#### wav ファイルの分割
+
+```bash
+python "$HOME/workspace/GenLipSyncVideo/scripts/separate.py" \
+  --input "$HOME/workspace/GenLipSyncVideo/data/raw/d_208302/d_208302_track_001.wav" \
+  --output "$HOME/workspace/GenLipSyncVideo/data/raw/separate" \
+  --dmm-id d_208302 \
+  --start 0 \
+  --interval 5 \
+  --duration 15
+```
+
+#### 引数の説明
+
+- `--input`: 入力する単一のWAVファイルのパス（例: `"$HOME/workspace/GenLipSyncVideo/data/raw/d_208302/d_208302_track_001.wav"`）
+- `--directory`: 入力する複数のWAVファイルが存在するディレクトリのパス
+- `--output`: 出力するディレクトリのパス（例: `"$HOME/workspace/GenLipSyncVideo/data/raw/separate"`）
+- `--dmm`-id: DMM ID（例: `d_208302`）。指定された場合、出力ディレクトリのパスに追加されます。
+- `--start`: 分割開始時間（秒）（例: `0`）
+- `--interval`: 分割間隔（秒）（例: `5`）
+- `--duration`: 各分割ファイルの長さ（秒）（例: `15`）
+
+#### 注意事項
+
+- `--input` または `--directory` のいずれかを指定する必要があります。両方指定されていない場合、エラーが発生します。
+- 出力ディレクトリが存在しない場合は、自動的に作成されます。

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
     "libportaudiocpp",
     "libsox",
     "portaudio",
+    "pydub",
     "pyenv",
     "shellcheck",
     "SSIA",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-torch>=2.0,<2.1
-torchvision>=0.15,<0.16
-torchaudio>=2.0,<2.1

--- a/scripts/separate.py
+++ b/scripts/separate.py
@@ -1,0 +1,70 @@
+import os
+import argparse
+from pydub import AudioSegment
+from argparse import Namespace
+
+def parse_arguments() -> Namespace:
+    parser = argparse.ArgumentParser(description='WAVファイルを指定の間隔で分割します。')
+    parser.add_argument('--input', help='入力する単一のWAVファイルのパス')
+    parser.add_argument('--directory', help='入力する複数のWAVファイルが存在するディレクトリのパス')
+    parser.add_argument('--output', required=True, help='出力するディレクトリのパス')
+    parser.add_argument('--dmm-id', help='DMM ID（例: d_208302）')
+    parser.add_argument('--start', type=int, required=True, help='分割開始時間（秒）')
+    parser.add_argument('--interval', type=int, required=True, help='分割間隔（秒）')
+    parser.add_argument('--duration', type=int, required=True, help='各分割ファイルの長さ（秒）')
+    return parser.parse_args()
+
+def main():
+    args = parse_arguments()
+
+    if not args.input and not args.directory:
+        print("エラー: --input または --directory のいずれかを指定してください。")
+        return
+
+    input_files = []
+    if args.input:
+        input_files.append(args.input)
+    if args.directory:
+        for file in os.listdir(args.directory):
+            if file.endswith(".wav"):
+                input_files.append(os.path.join(args.directory, file))
+
+    output_dir = args.output
+    dmm_id = args.dmm_id
+    start_time = args.start * 1000  # ミリ秒に変換
+    interval = args.interval * 1000  # ミリ秒に変換
+    duration = args.duration * 1000  # ミリ秒に変換
+
+    # 出力ディレクトリの存在確認
+    if not os.path.isdir(output_dir):
+        print(f"出力ディレクトリが見つかりません: {output_dir}")
+        return
+
+    for input_file in input_files:
+        # 入力ファイルの存在確認
+        if not os.path.isfile(input_file):
+            print(f"入力ファイルが見つかりません: {input_file}")
+            continue
+
+        # 出力ディレクトリの作成
+        output_path = os.path.join(output_dir, dmm_id) if dmm_id else output_dir
+        os.makedirs(output_path, exist_ok=True)
+
+        # オーディオファイルの読み込み
+        audio = AudioSegment.from_wav(input_file)
+        audio_length = len(audio)
+
+        segment_number = 1
+        current_time = start_time
+
+        while current_time + duration <= audio_length:
+            segment = audio[current_time:current_time + duration]
+            output_filename = f"{os.path.splitext(os.path.basename(input_file))[0]}_track_{segment_number:03d}.wav"
+            output_filepath = os.path.join(output_path, output_filename)
+            segment.export(output_filepath, format="wav")
+            print(f"出力ファイル: {output_filepath}")
+            segment_number += 1
+            current_time += interval
+
+if __name__ == "__main__":
+    main()

--- a/scripts/separate.py
+++ b/scripts/separate.py
@@ -3,16 +3,24 @@ import argparse
 from pydub import AudioSegment
 from argparse import Namespace
 
+
 def parse_arguments() -> Namespace:
-    parser = argparse.ArgumentParser(description='WAVファイルを指定の間隔で分割します。')
-    parser.add_argument('--input', help='入力する単一のWAVファイルのパス')
-    parser.add_argument('--directory', help='入力する複数のWAVファイルが存在するディレクトリのパス')
-    parser.add_argument('--output', required=True, help='出力するディレクトリのパス')
-    parser.add_argument('--dmm-id', help='DMM ID（例: d_208302）')
-    parser.add_argument('--start', type=int, required=True, help='分割開始時間（秒）')
-    parser.add_argument('--interval', type=int, required=True, help='分割間隔（秒）')
-    parser.add_argument('--duration', type=int, required=True, help='各分割ファイルの長さ（秒）')
+    parser = argparse.ArgumentParser(
+        description="WAVファイルを指定の間隔で分割します。"
+    )
+    parser.add_argument("--input", help="入力する単一のWAVファイルのパス")
+    parser.add_argument(
+        "--directory", help="入力する複数のWAVファイルが存在するディレクトリのパス"
+    )
+    parser.add_argument("--output", required=True, help="出力するディレクトリのパス")
+    parser.add_argument("--dmm-id", help="DMM ID（例: d_208302）")
+    parser.add_argument("--start", type=int, required=True, help="分割開始時間（秒）")
+    parser.add_argument("--interval", type=int, required=True, help="分割間隔（秒）")
+    parser.add_argument(
+        "--duration", type=int, required=True, help="各分割ファイルの長さ（秒）"
+    )
     return parser.parse_args()
+
 
 def main():
     args = parse_arguments()
@@ -58,13 +66,14 @@ def main():
         current_time = start_time
 
         while current_time + duration <= audio_length:
-            segment = audio[current_time:current_time + duration]
+            segment = audio[current_time : current_time + duration]
             output_filename = f"{os.path.splitext(os.path.basename(input_file))[0]}_track_{segment_number:03d}.wav"
             output_filepath = os.path.join(output_path, output_filename)
             segment.export(output_filepath, format="wav")
             print(f"出力ファイル: {output_filepath}")
             segment_number += 1
             current_time += interval
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/speech-to-text.py
+++ b/scripts/speech-to-text.py
@@ -1,0 +1,66 @@
+import os
+import argparse
+from argparse import Namespace
+import whisper
+
+def parse_arguments() -> Namespace:
+    parser = argparse.ArgumentParser(description="WAVファイルをテキストに変換します。")
+    parser.add_argument("--input", help="入力する単一のWAVファイルのパス")
+    parser.add_argument("--directory", help="入力する複数のWAVファイルが存在するディレクトリのパス")
+    parser.add_argument("--output", required=True, help="出力するディレクトリのパス")
+    parser.add_argument("--dmm-id", help="DMM ID（例: d_208302）")
+    parser.add_argument("--model", default="base", help="使用するWhisperモデルの名前（例: tiny, base, small, medium, large）")
+    return parser.parse_args()
+
+def transcribe_audio(input_file: str, output_file: str, model_name: str):
+    model = whisper.load_model(model_name)
+    result = model.transcribe(input_file)
+    text = result["text"]
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write(text)
+    print(f"出力ファイル: {output_file}")
+
+def main():
+    args = parse_arguments()
+
+    if not args.input and not args.directory:
+        print("エラー: --input または --directory のいずれかを指定してください。")
+        return
+
+    input_files = []
+    if args.input:
+        input_files.append(args.input)
+    if args.directory:
+        for file in os.listdir(args.directory):
+            if file.endswith(".wav"):
+                input_files.append(os.path.join(args.directory, file))
+
+    output_dir = args.output
+    dmm_id = args.dmm_id
+    model_name = args.model
+
+    # 出力ディレクトリの存在確認
+    if not os.path.isdir(output_dir):
+        print(f"出力ディレクトリが見つかりません: {output_dir}")
+        return
+
+    for input_file in input_files:
+        # 入力ファイルの存在確認
+        if not os.path.isfile(input_file):
+            print(f"入力ファイルが見つかりません: {input_file}")
+            continue
+
+        # 出力ディレクトリの作成
+        output_path = os.path.join(output_dir, dmm_id) if dmm_id else output_dir
+        os.makedirs(output_path, exist_ok=True)
+
+        # 出力ファイルのパスを生成
+        output_file = os.path.join(
+            output_path, os.path.splitext(os.path.basename(input_file))[0] + ".txt"
+        )
+
+        # 音声をテキストに変換
+        transcribe_audio(input_file, output_file, model_name)
+
+if __name__ == "__main__":
+    main()

--- a/setup
+++ b/setup
@@ -50,7 +50,7 @@ source .venv/bin/activate
 python -V
 uv pip install --upgrade pip
 uv add --dev --python "$PYTHON_VERSION" torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1
-uv add --dev --python "$PYTHON_VERSION" click pydub
+uv add --dev --python "$PYTHON_VERSION" click pydub fish-audio-preprocess
 
 # モデルのダウンロード先ディレクトリを作成
 mkdir -p "$FS_ROOT/models/checkpoints"

--- a/setup
+++ b/setup
@@ -10,6 +10,7 @@ sudo apt update
 sudo apt install -y \
     build-essential \
     cmake \
+    clang \
     libsox-dev \
     ffmpeg \
     libasound-dev \
@@ -23,6 +24,9 @@ sudo apt install -y \
 # huggingface_hub をインストール
 pip install huggingface_hub
 
+git clone https://github.com/fishaudio/fish-speech
+cd ./fish-speech
+
 PYTHON_VERSION=3.10.0
 
 # 仮想環境の作成
@@ -32,9 +36,6 @@ source .venv/bin/activate
 python -V
 uv pip install --upgrade pip
 uv add --dev --python "$PYTHON_VERSION" torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1
-
-# Fish Speech の依存関係をインストール
-# pip install -e "$HOME/workspace/fish-speech"[stable]
 
 # huggingface-cli がインストールされているか確認
 if ! command -v huggingface-cli &> /dev/null; then
@@ -48,19 +49,5 @@ mkdir -p ./models/checkpoints
 # モデルをダウンロード
 huggingface-cli download fishaudio/fish-speech-1.4 \
     --local-dir ./models/checkpoints/fish-speech-1.4
-
-# $HOME/workspace ディレクトリが存在しない場合は作成
-mkdir -p "$HOME/workspace"
-
-# fish-speech リポジトリをクローンまたは更新
-if [ ! -d "$HOME/workspace/fish-speech" ]; then
-    echo "Fish Speech リポジトリをクローンしています..."
-    git clone https://github.com/fishaudio/fish-speech.git "$HOME/workspace/fish-speech"
-fi
-
-echo "Fish Speech リポジトリが既に存在します。最新の状態に更新します..."
-git -C "$HOME/workspace/fish-speech" pull origin main
-git -C "$HOME/workspace/fish-speech" switch main
-
 
 echo "セットアップが完了しました。"

--- a/setup
+++ b/setup
@@ -59,4 +59,6 @@ mkdir -p "$FS_ROOT/models/checkpoints"
 huggingface-cli download fishaudio/fish-speech-1.4 \
     --local-dir "$HOME/workspace/GenLipSyncVideo/models/checkpoints/fish-speech-1.4"
 
+mkdir -p ./data/raw/separate
+
 echo "セットアップが完了しました。"

--- a/setup
+++ b/setup
@@ -2,8 +2,7 @@
 
 set -ex  # エラー時に終了し、実行コマンドを表示
 
-# 仮想環境をディアクティベート
-deactivate 2>/dev/null || true
+FS_ROOT="$HOME/workspace/fish-speech"
 
 # 必要なシステムパッケージをインストール
 sudo apt update
@@ -24,12 +23,27 @@ sudo apt install -y \
 # huggingface_hub をインストール
 pip install huggingface_hub
 
-git clone https://github.com/fishaudio/fish-speech
-cd ./fish-speech
+# huggingface-cli がインストールされているか確認
+if ! command -v huggingface-cli &> /dev/null; then
+    echo "huggingface-cli のインストールに失敗しました。"
+    exit 1
+fi
 
-PYTHON_VERSION=3.10.0
+if [ ! -d "$FS_ROOT" ]; then
+    mkdir -p "$HOME/workspace"
+    git clone https://github.com/fishaudio/fish-speech "$FS_ROOT"
+    cd ./fish-speech
+fi
+
+git -C "$FS_ROOT" switch main
+git -C "$FS_ROOT" fetch -p
+git -C "$FS_ROOT" pull
+
+# 作業ディレクトリに移動
+cd "$FS_ROOT"
 
 # 仮想環境の作成
+PYTHON_VERSION=3.10.0
 uv venv --python "$PYTHON_VERSION"
 # shellcheck source=/dev/null
 source .venv/bin/activate
@@ -38,17 +52,11 @@ uv pip install --upgrade pip
 uv add --dev --python "$PYTHON_VERSION" torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1
 uv add --dev --python "$PYTHON_VERSION" click
 
-# huggingface-cli がインストールされているか確認
-if ! command -v huggingface-cli &> /dev/null; then
-    echo "huggingface-cli のインストールに失敗しました。"
-    exit 1
-fi
-
 # モデルのダウンロード先ディレクトリを作成
-mkdir -p ./models/checkpoints
+mkdir -p "$FS_ROOT/models/checkpoints"
 
 # モデルをダウンロード
 huggingface-cli download fishaudio/fish-speech-1.4 \
-    --local-dir ./models/checkpoints/fish-speech-1.4
+    --local-dir "$HOME/workspace/GenLipSyncVideo/models/checkpoints/fish-speech-1.4"
 
 echo "セットアップが完了しました。"

--- a/setup
+++ b/setup
@@ -50,7 +50,7 @@ source .venv/bin/activate
 python -V
 uv pip install --upgrade pip
 uv add --dev --python "$PYTHON_VERSION" torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1
-uv add --dev --python "$PYTHON_VERSION" click
+uv add --dev --python "$PYTHON_VERSION" click pydub
 
 # モデルのダウンロード先ディレクトリを作成
 mkdir -p "$FS_ROOT/models/checkpoints"

--- a/setup
+++ b/setup
@@ -36,6 +36,7 @@ source .venv/bin/activate
 python -V
 uv pip install --upgrade pip
 uv add --dev --python "$PYTHON_VERSION" torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1
+uv add --dev --python "$PYTHON_VERSION" click
 
 # huggingface-cli がインストールされているか確認
 if ! command -v huggingface-cli &> /dev/null; then

--- a/setup
+++ b/setup
@@ -23,11 +23,8 @@ sudo apt install -y \
 # huggingface_hub をインストール
 pip install huggingface_hub
 
-# .python-version ファイルから Python のバージョンを取得
-PYTHON_VERSION=3.10.0
-
 # 仮想環境の作成
-uv venv --python $PYTHON_VERSION
+uv venv --python 3.10.0
 # shellcheck source=/dev/null
 source .venv/bin/activate
 python -V

--- a/setup
+++ b/setup
@@ -20,9 +20,6 @@ sudo apt install -y \
     python3-venv \
     git
 
-# pyenv をインストール
-pyenv install 3.13.0
-
 # huggingface_hub をインストール
 pip install huggingface_hub
 

--- a/setup
+++ b/setup
@@ -23,13 +23,15 @@ sudo apt install -y \
 # huggingface_hub をインストール
 pip install huggingface_hub
 
+PYTHON_VERSION=3.10.0
+
 # 仮想環境の作成
-uv venv --python 3.10.0
+uv venv --python "$PYTHON_VERSION"
 # shellcheck source=/dev/null
 source .venv/bin/activate
 python -V
 uv pip install --upgrade pip
-uv add --dev torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1
+uv add --dev --python "$PYTHON_VERSION" torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1
 
 # Fish Speech の依存関係をインストール
 # pip install -e "$HOME/workspace/fish-speech"[stable]

--- a/setup
+++ b/setup
@@ -60,5 +60,6 @@ huggingface-cli download fishaudio/fish-speech-1.4 \
     --local-dir "$HOME/workspace/GenLipSyncVideo/models/checkpoints/fish-speech-1.4"
 
 mkdir -p ./data/raw/separate
+mkdir -p ./data/speech-to-text
 
 echo "セットアップが完了しました。"

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "pydub" },
     { name = "torch" },
     { name = "torchaudio" },
     { name = "torchvision" },
@@ -35,6 +36,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pydub", specifier = ">=0.25.1" },
     { name = "torch", specifier = "==2.4.1" },
     { name = "torchaudio", specifier = "==2.4.1" },
     { name = "torchvision", specifier = "==0.19.1" },
@@ -364,6 +366,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/75/689b4ec0483c42bfc7d1aacd32ade7a226db4f4fac57c6fdcdf90c0731e3/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:73853108f56df97baf2bb8b522f3578221e56f646ba345a372c78326710d3830", size = 3310533 },
     { url = "https://files.pythonhosted.org/packages/3d/30/38bd6149cf53da1db4bad304c543ade775d225961c4310f30425995cb9ec/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e58876c91f97b0952eb766123bfef372792ab3f4e3e1f1a2267834c2ab131734", size = 3414886 },
     { url = "https://files.pythonhosted.org/packages/ec/3d/c32a51d848401bd94cabb8767a39621496491ee7cd5199856b77da9b18ad/pillow-11.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:224aaa38177597bb179f3ec87eeefcce8e4f85e608025e9cfac60de237ba6316", size = 2567508 },
+]
+
+[[package]]
+name = "pydub"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327 },
 ]
 
 [[package]]


### PR DESCRIPTION

## 📒 変更点の概要

- `setup` スクリプトを更新し、新しい依存関係 `fish-audio-preprocess` を追加しました。
- `README.md` を更新し、OpenAI Whisperを使用した音声からテキストへの変換スクリプトの説明と引数を追加しました。
- `.gitignore` に `speech-to-text` ディレクトリを追加しました。
- 音声ファイルをテキストに変換するスクリプト `speech-to-text.py` を追加しました。
- WAVファイルを指定の間隔で分割するスクリプト `separate.py` を追加しました。

## ⚒ 技術的な詳細

- `speech-to-text.py` は、OpenAI Whisperモデルを使用してWAVファイルをテキストに変換します。引数として入力ファイル、出力ディレクトリ、DMM ID、使用するモデルを指定できます。
- `separate.py` は、指定されたWAVファイルを指定の間隔で分割します。引数として入力ファイル、出力ディレクトリ、DMM ID、開始時間、分割間隔、各分割ファイルの長さを指定できます。
- `setup` スクリプトでは、必要なPythonパッケージをインストールし、データ用のディレクトリを作成します。

## ⚠ 注意点

- `speech-to-text.py` と `separate.py` の両方で、入力ファイルまたはディレクトリが指定されていない場合、エラーメッセージが表示されます。
- 出力ディレクトリが存在しない場合は、自動的に作成されますが、指定されたパスが正しいことを確認してください。